### PR TITLE
Infer model on all test images and overlay masks

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -43,6 +43,8 @@ class BaseModel:
         if not self.isTrain or self.opt.train.resume_checkpoint:
             load_suffix = "iter_%d" % self.opt.train.load_iter
             self.load_networks(load_suffix)
+        if not self.isTrain:
+            self.eval()
 
         self.print_networks(self.opt.model.verbose)
 

--- a/shared/defaults.yml
+++ b/shared/defaults.yml
@@ -130,3 +130,4 @@ val:
   max_log_images: 1
   save_im_freq: 1000
   store_images: false # write to disk on top of comet logging
+  overlay: false

--- a/shared/sim.yml
+++ b/shared/sim.yml
@@ -4,7 +4,7 @@
 # ----------------
 data:
   files: # if one is not none it will override the dirs location
-    base: "/network/tmp1/ccai/data/mask_generation"
+    base: "/network/tmp1/ccai/data/mask_generation/11k"
     train: train.json
     val: test.json
 
@@ -124,9 +124,9 @@ train:
   print_freq: 1
   output_dir: './outputs'
   save_im_freq: 100
-  save_freq: 1000
+  save_freq: 20000
   resume_checkpoint: false
-  load_iter: 4000
+  load_iter: 500000
 
 
 # -----------------------------
@@ -136,3 +136,4 @@ val:
   max_log_images: 1
   store_images: false # write to disk on top of comet logging
   save_im_freq: 1000
+  overlay: true

--- a/test.py
+++ b/test.py
@@ -1,0 +1,47 @@
+import time
+from pathlib import Path
+from comet_ml import Experiment
+import sys
+from utils import *
+from data.datasets import get_loader
+import copy
+
+
+# from data import CreateDataLoader
+# from models import create_model
+# from util.visualizer import Visualizer
+
+if __name__ == "__main__":
+    root = Path(__file__).parent.resolve()
+    opt_file = "shared/sim.yml"
+
+    opt = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
+
+    opt = set_mode("test", opt)
+    opt.data.loaders.batch_size = 1
+    val_loader = get_loader(opt)
+    dataset_size = len(val_loader)
+
+    print("#testing images = %d" % dataset_size)
+
+    comet_exp = Experiment(workspace=opt.comet.workspace, project_name=opt.comet.project_name)
+    if comet_exp is not None:
+        comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
+        comet_exp.log_parameters(opt)
+
+    checkpoint_directory, image_directory = prepare_sub_folder(opt.train.output_dir)
+
+    opt.comet.exp = comet_exp
+
+    model = create_model(opt)
+    model.setup()
+
+    total_steps = 0
+
+    for i, data in enumerate(val_loader):
+        with Timer("Elapsed time in update " + str(i) + ": %f"):
+            total_steps += opt.data.loaders.batch_size
+            model.set_input(Dict(data))
+            print(Dict(data).data.keys())
+            model.save_test_images([Dict(data)], total_steps)
+

--- a/train.py
+++ b/train.py
@@ -6,14 +6,13 @@ from utils import *
 from data.datasets import get_loader
 import copy
 
-
 # from data import CreateDataLoader
 # from models import create_model
 # from util.visualizer import Visualizer
 
 if __name__ == "__main__":
     root = Path(__file__).parent.resolve()
-    opt_file = "shared/sim.yml"
+    opt_file = "example_files/testing.yml"
 
     opt = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
     opt = set_mode("train", opt)

--- a/utils.py
+++ b/utils.py
@@ -60,10 +60,11 @@ def set_data_paths(opts):
 
 
 def set_mode(mode, opts):
+
     if mode == "train":
-        opts.mode.is_train = True
+        opts.model.is_train = True
     elif mode == "test":
-        opts.mode.is_train = False
+        opts.model.is_train = False
 
     return opts
 


### PR DESCRIPTION
Added code to infer model on all test images in the opt.data.val directory. Option to overlay mask on logged image (rather than just log mask itself)