### PR TITLE
Vic refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # MaskGenerator
 End-to-end trainable mask generation
+
+
+`...D_P` is for the pixel-level Domain Adaptation discriminator
+
+`...D_F` is for the feature-level (latent-vector actually) Domain Adaptation discriminator

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -39,7 +39,11 @@ class SimDataset(Dataset):
         """Checks that every file listed in samples_paths actually
         exist on the file-system
         """
-        print(f"Cheking samples in {self.file_list_path}...", end="", flush=True)
+        print(
+            f"Cheking {len(self.samples_paths)} samples in {self.file_list_path}...",
+            end="",
+            flush=True,
+        )
         for s in self.samples_paths:
             for k, v in s.items():
                 assert Path(v).exists(), f"{k} {v} does not exist"

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -30,8 +30,8 @@ class SimDataset(Dataset):
         else:
             raise ValueError("Unknown file list type in {}".format(file_list_path))
 
-        self.check_samples()
         self.file_list_path = str(file_list_path)
+        self.check_samples()
         self.transform = transform
         self.opts = opts
 
@@ -39,9 +39,11 @@ class SimDataset(Dataset):
         """Checks that every file listed in samples_paths actually
         exist on the file-system
         """
+        print(f"Cheking samples in {self.file_list_path}...", end="", flush=True)
         for s in self.samples_paths:
             for k, v in s.items():
                 assert Path(v).exists(), f"{k} {v} does not exist"
+        print(" ok.")
 
     def json_load(self, file_path):
         with open(file_path, "r") as f:

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -41,13 +41,8 @@ class SimDataset(Dataset):
         """Checks that every file listed in samples_paths actually
         exist on the file-system
         """
-        print(
-            "Cheking {} samples in {}...".format(
-                len(self.samples_paths), self.file_list_path
-            ),
-            end="",
-            flush=True,
-        )
+        l, p = (len(self.samples_paths), self.file_list_path)
+        print(f"Cheking {l} samples in {p}...", end="", flush=True)
         for s in self.samples_paths:
             for k, v in s.items():
                 assert Path(v).exists(), f"{k} {v} does not exist"

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -159,7 +159,7 @@ class RealSimDataset(Dataset):
         exist on the file-system
         """
         l, p = (len(self.samples_paths), self.file_list_path)
-        print(f"Cheking {l} samples in {p}...", end="", flush=True)
+        print(f"Checking {l} samples in {p}...", end="", flush=True)
 
         for s in self.samples_paths:
             for k, v in s.items():

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -168,7 +168,7 @@ class RealSimDataset(Dataset):
         print(" ok.")
 
         l, p = (len(self.real_samples_paths), self.real_file_list_path)
-        print(f"Cheking {l} samples in {p}...", end="", flush=True)
+        print(f"Checking {l} samples in {p}...", end="", flush=True)
 
         for s in self.real_samples_paths:
             for k, v in s.items():

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -33,7 +33,6 @@ class SimDataset(Dataset):
         self.file_list_path = str(file_list_path)
         if not no_check:
             self.check_samples()
-        self.check_samples()
         self.transform = transform
         self.opts = opts
 
@@ -42,7 +41,7 @@ class SimDataset(Dataset):
         exist on the file-system
         """
         l, p = (len(self.samples_paths), self.file_list_path)
-        print(f"Cheking {l} samples in {p}...", end="", flush=True)
+        print(f"Checking {l} samples in {p}...", end="", flush=True)
         for s in self.samples_paths:
             for k, v in s.items():
                 assert Path(v).exists(), f"{k} {v} does not exist"

--- a/data/datasets.py
+++ b/data/datasets.py
@@ -226,13 +226,13 @@ def get_loader(opts, real=True):
                 opts, transform=transforms.Compose(get_transforms(Dict(opts)))
             ),
             batch_size=opts.data.loaders.get("batch_size", 4),
-            shuffle=True,
+            shuffle=opts.model.is_train,
             num_workers=opts.data.loaders.get("num_workers", 8),
         )
     else:
         return DataLoader(
             SimDataset(opts, transform=transforms.Compose(get_transforms(Dict(opts)))),
             batch_size=opts.data.loaders.get("batch_size", 4),
-            shuffle=True,
+            shuffle=opts.model.is_train,
             num_workers=opts.data.loaders.get("num_workers", 8),
         )

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -141,7 +141,7 @@ class BaseModel:
                 )
         print("-----------------------------------------------")
 
-    # set requies_grad=Fasle to avoid computation
+    # set requires_grad=False to avoid computation
     def set_requires_grad(self, nets, requires_grad=False):
         if not isinstance(nets, list):
             nets = [nets]

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -13,17 +13,17 @@ class BaseModel:
     def name(self):
         return "BaseModel"
 
-    def initialize(self, opt):
-        self.opt = opt
-        self.use_gpu = opt.model.use_gpu
+    def initialize(self, opts):
+        self.opts = opts
+        self.use_gpu = opts.model.use_gpu
         self.device = torch.device(
-            "cuda" if (torch.cuda.is_available() and opt.model.use_gpu) else "cpu"
+            "cuda" if (torch.cuda.is_available() and opts.model.use_gpu) else "cpu"
         )
-        self.isTrain = opt.model.is_train
+        self.isTrain = opts.model.is_train
         self.loss_names = []
         self.model_names = []
-        self.comet_exp = opt.comet_exp
-        self.save_dir = opt.train.output_dir + "/checkpoints"
+        self.comet_exp = opts.comet_exp
+        self.save_dir = opts.train.output_dir + "/checkpoints"
 
     def set_input(self, input):
         pass
@@ -38,13 +38,13 @@ class BaseModel:
     def setup(self):
         # TODO Resume training
 
-        if not self.isTrain or self.opt.train.resume_checkpoint:
-            load_suffix = "iter_%d" % self.opt.train.load_iter
+        if not self.isTrain or self.opts.train.resume_checkpoint:
+            load_suffix = "iter_%d" % self.opts.train.load_iter
             self.load_networks(load_suffix)
         if not self.isTrain:
             self.eval()
 
-        self.print_networks(self.opt.model.verbose)
+        self.print_networks(self.opts.model.verbose)
 
     # make models eval mode during test time
     def eval(self):

--- a/models/mask_generator.py
+++ b/models/mask_generator.py
@@ -127,9 +127,13 @@ class MaskGenerator(BaseModel):
 
         # Log D loss to comet:
         if self.comet_exp is not None:
-            self.comet_exp.log_metric("loss D", self.loss_D.cpu().detach())
-            self.comet_exp.log_metric("loss D real", self.loss_D_real.cpu().detach())
-            self.comet_exp.log_metric("loss D fake", self.loss_D_fake.cpu().detach())
+            self.comet_exp.log_metrics(
+                {
+                    "loss D": self.loss_D.cpu().detach(),
+                    "loss D real": self.loss_D_real.cpu().detach(),
+                    "loss D fake": self.loss_D_fake.cpu().detach(),
+                }
+            )
 
         # backward
         self.loss_D.backward()
@@ -152,12 +156,12 @@ class MaskGenerator(BaseModel):
 
         # Log D loss to comet:
         if self.comet_exp is not None:
-            self.comet_exp.log_metric("loss D Pixel DA", self.loss_D_P.cpu().detach())
-            self.comet_exp.log_metric(
-                "loss D Pixel DA sim", self.loss_D_P_sim.cpu().detach()
-            )
-            self.comet_exp.log_metric(
-                "loss D Pixel DA real", self.loss_D_P_real.cpu().detach()
+            self.comet_exp.log_metrics(
+                {
+                    "loss D Pixel DA": self.loss_D_P.cpu().detach(),
+                    "loss D Pixel DA sim": self.loss_D_P_sim.cpu().detach(),
+                    "loss D Pixel DA real": self.loss_D_P_real.cpu().detach(),
+                }
             )
 
         # backward
@@ -181,12 +185,12 @@ class MaskGenerator(BaseModel):
 
         # Log D loss to comet:
         if self.comet_exp is not None:
-            self.comet_exp.log_metric("loss D Feature DA", self.loss_D_F.cpu().detach())
-            self.comet_exp.log_metric(
-                "loss D Feature DA sim", self.loss_D_F_sim.cpu().detach()
-            )
-            self.comet_exp.log_metric(
-                "loss D Feature DA real", self.loss_D_F_real.cpu().detach()
+            self.comet_exp.log_metrics(
+                {
+                    "loss D Feature DA": self.loss_D_F.cpu().detach(),
+                    "loss D Feature DA sim": self.loss_D_F_sim.cpu().detach(),
+                    "loss D Feature DA real": self.loss_D_F_real.cpu().detach(),
+                }
             )
 
         # backward
@@ -210,16 +214,15 @@ class MaskGenerator(BaseModel):
         self.loss_G = self.loss_G_standard + (self.loss_G_DA_F + self.loss_G_DA_P) * 0.5
         # Log G loss to comet:
         if self.comet_exp is not None:
-            self.comet_exp.log_metric("loss G", self.loss_G.cpu().detach())
-            self.comet_exp.log_metric(
-                "loss G standard", self.loss_G_standard.cpu().detach()
+            self.comet_exp.log_metrics(
+                {
+                    "loss G": self.loss_G.cpu().detach(),
+                    "loss G standard": self.loss_G_standard.cpu().detach(),
+                    "loss G Feature DA": self.loss_G_DA_F.cpu().detach(),
+                    "loss G Pixel DA": self.loss_G_DA_P.cpu().detach(),
+                }
             )
-            self.comet_exp.log_metric(
-                "loss G Feature DA", self.loss_G_DA_F.cpu().detach()
-            )
-            self.comet_exp.log_metric(
-                "loss G Pixel DA", self.loss_G_DA_P.cpu().detach()
-            )
+
         self.loss_G.backward()
 
     def optimize_parameters(self):

--- a/models/mask_generator.py
+++ b/models/mask_generator.py
@@ -3,7 +3,7 @@ import itertools
 from .base_model import BaseModel
 from . import networks
 from utils import write_images
-
+from time import time
 
 # Domain adaptation for real data
 class MaskGenerator(BaseModel):
@@ -253,6 +253,7 @@ class MaskGenerator(BaseModel):
         self.optimizer_D_P.step()
 
     def save_test_images(self, test_display_data, curr_iter):
+        st = time()
         overlay = self.overlay
         save_images = []
         for i in range(len(test_display_data)):
@@ -299,3 +300,5 @@ class MaskGenerator(BaseModel):
         write_images(
             save_images, curr_iter, comet_exp=self.comet_exp, store_im=self.store_image
         )
+
+        return time() - st

--- a/models/mask_generator.py
+++ b/models/mask_generator.py
@@ -65,23 +65,23 @@ class MaskGenerator(BaseModel):
 
             self.optimizer_G = torch.optim.Adam(
                 itertools.chain(self.netG.parameters()),
-                lr=opts.gen.opts.lr,
-                betas=(opts.gen.opts.beta1, 0.999),
+                lr=opts.gen.optim.lr,
+                betas=(opts.gen.optim.beta1, 0.999),
             )
             self.optimizer_D = torch.optim.Adam(
                 itertools.chain(self.netD.parameters()),
-                lr=opts.dis.opts.lr,
-                betas=(opts.dis.opts.beta1, 0.999),
+                lr=opts.dis.optim.lr,
+                betas=(opts.dis.optim.beta1, 0.999),
             )
             self.optimizer_D_F = torch.optim.Adam(
                 itertools.chain(self.netD_F.parameters()),
-                lr=opts.dis.opts.lr,
-                betas=(opts.dis.opts.beta1, 0.999),
+                lr=opts.dis.optim.lr,
+                betas=(opts.dis.optim.beta1, 0.999),
             )
             self.optimizer_D_P = torch.optim.Adam(
                 itertools.chain(self.netD_P.parameters()),
-                lr=opts.dis.opts.lr,
-                betas=(opts.dis.opts.beta1, 0.999),
+                lr=opts.dis.optim.lr,
+                betas=(opts.dis.optim.beta1, 0.999),
             )
             self.optimizers = []
             self.optimizers.append(self.optimizer_G)

--- a/models/mask_generator.py
+++ b/models/mask_generator.py
@@ -117,14 +117,13 @@ class MaskGenerator(BaseModel):
         pred_fake = self.netD(fake_mask_d.detach())
         self.loss_D_fake = self.criterionGAN(pred_fake, False)
 
+        self.loss_D = (self.loss_D_real + self.loss_D_fake) * 0.5
+
         if self.loss_name == "wgan":  # Get gradient penalty loss
             grad_penalty = networks.calc_gradient_penalty(
                 self.opts, self.netD, real_mask_d, fake_mask_d
             )
-            self.loss_D = (self.loss_D_real + self.loss_D_fake) * 0.5 + grad_penalty
-        else:
-            # Combined loss
-            self.loss_D = (self.loss_D_real + self.loss_D_fake) * 0.5
+            self.loss_D += grad_penalty
 
         # Log D loss to comet:
         if self.comet_exp is not None:
@@ -143,17 +142,13 @@ class MaskGenerator(BaseModel):
         # Fake (real)
         pred_domain_real = self.netD_P(self.r_fake_mask.detach())
         self.loss_D_P_real = self.criterionGAN(pred_domain_real, False)
+        self.loss_D_P = (self.loss_D_P_sim + self.loss_D_P_real) * 0.5
 
         if self.loss_name == "wgan":  # Get gradient penalty loss
             grad_penalty = networks.calc_gradient_penalty(
                 self.opts, self.netD_P, self.mask, self.r_fake_mask
             )
-            self.loss_D_P = (
-                self.loss_D_P_sim + self.loss_D_P_real
-            ) * 0.5 + grad_penalty
-        else:
-            # Combined loss
-            self.loss_D_P = (self.loss_D_P_sim + self.loss_D_P_real) * 0.5
+            self.loss_D_P += 0.5 + grad_penalty
 
         # Log D loss to comet:
         if self.comet_exp is not None:
@@ -176,17 +171,13 @@ class MaskGenerator(BaseModel):
 
         pred_domain_real = self.netD_F(self.real_latent_vec.detach())
         self.loss_D_F_real = self.criterionGAN(pred_domain_real, False)
-        ###
+        self.loss_D_F = (self.loss_D_F_sim + self.loss_D_F_real) * 0.5
+
         if self.loss_name == "wgan":  # Get gradient penalty loss
             grad_penalty = networks.calc_gradient_penalty(
                 self.opts, self.netD_F, self.sim_latent_vec, self.real_latent_vec
             )
-            self.loss_D_F = (
-                self.loss_D_F_sim + self.loss_D_F_real
-            ) * 0.5 + grad_penalty
-        else:
-            # Combined loss
-            self.loss_D_F = (self.loss_D_F_sim + self.loss_D_F_real) * 0.5
+            self.loss_D_F += 0.5 + grad_penalty
 
         # Log D loss to comet:
         if self.comet_exp is not None:

--- a/models/networks.py
+++ b/models/networks.py
@@ -63,10 +63,10 @@ def get_norm_layer(norm_type="instance"):
 #    #Use 0.5 threshold to determine whether real or fake
 
 
-def calc_gradient_penalty(opt, netD, real_data, fake_data):
-    DIM = opt.data.img_size
+def calc_gradient_penalty(opts, netD, real_data, fake_data):
+    DIM = opts.data.img_size
     LAMBDA = 10
-    nc = opt.dis.default.input_nc
+    nc = opts.dis.default.input_nc
     alpha = torch.rand(real_data.shape)
     # alpha = alpha.view(batch_size, nc, DIM, DIM)
     # alpha = alpha.expand(
@@ -139,8 +139,8 @@ def define_G(opts):
     dec_norm = opts.gen.decoder.norm
     res_norm = opts.gen.encoder.res_norm
 
-    init_type = opts.gen.opt.init_type
-    init_gain = opts.gen.opt.init_gain
+    init_type = opts.gen.opts.init_type
+    init_gain = opts.gen.opts.init_gain
 
     net = None
 
@@ -174,8 +174,8 @@ def define_D(opts):
     nf_mult = opts.dis.default.nf_mult
     nf_mult_prev = opts.dis.default.nf_mult_prev
 
-    init_type = opts.gen.opt.init_type
-    init_gain = opts.gen.opt.init_gain
+    init_type = opts.gen.opts.init_type
+    init_gain = opts.gen.opts.init_gain
 
     net = None
 

--- a/models/networks.py
+++ b/models/networks.py
@@ -139,8 +139,8 @@ def define_G(opts):
     dec_norm = opts.gen.decoder.norm
     res_norm = opts.gen.encoder.res_norm
 
-    init_type = opts.gen.opts.init_type
-    init_gain = opts.gen.opts.init_gain
+    init_type = opts.gen.optim.init_type
+    init_gain = opts.gen.optim.init_gain
 
     net = None
 
@@ -174,8 +174,8 @@ def define_D(opts):
     nf_mult = opts.dis.default.nf_mult
     nf_mult_prev = opts.dis.default.nf_mult_prev
 
-    init_type = opts.gen.opts.init_type
-    init_gain = opts.gen.opts.init_gain
+    init_type = opts.gen.optim.init_type
+    init_gain = opts.gen.optim.init_gain
 
     net = None
 

--- a/models/sim_mask_generator.py
+++ b/models/sim_mask_generator.py
@@ -15,13 +15,13 @@ class SimMaskGenerator(BaseModel):
         print("modifying opts")
         return opts
 
-    def initialize(self, opt):
-        BaseModel.initialize(self, opt)
+    def initialize(self, opts):
+        BaseModel.initialize(self, opts)
 
         # specify the training losses you want to print out.
         # The program will call base_model.get_current_losses
         self.loss_names = []
-        self.loss_name = opt.model.loss_name
+        self.loss_name = opts.model.loss_name
 
         # specify the models you want to save to the disk.
         # The program will call base_model.save_networks and base_model.load_networks
@@ -36,12 +36,12 @@ class SimMaskGenerator(BaseModel):
         # load/define networks
         # The naming conversion is different from those used in the paper
         # Code (paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
-        self.netG = networks.define_G(opt).to(self.device)
-        self.netD = networks.define_D(opt).to(self.device)
-        self.comet_exp = opt.comet.exp
-        self.store_image = opt.val.store_image
-        self.overlay = opt.val.overlay
-        self.opt = opt
+        self.netG = networks.define_G(opts).to(self.device)
+        self.netD = networks.define_D(opts).to(self.device)
+        self.comet_exp = opts.comet.exp
+        self.store_image = opts.val.store_image
+        self.overlay = opts.val.overlay
+        self.opts = opts
 
         if self.isTrain:
             # define loss functions
@@ -50,13 +50,13 @@ class SimMaskGenerator(BaseModel):
 
             self.optimizer_G = torch.optim.Adam(
                 itertools.chain(self.netG.parameters()),
-                lr=opt.gen.opt.lr,
-                betas=(opt.gen.opt.beta1, 0.999),
+                lr=opts.gen.opts.lr,
+                betas=(opts.gen.opts.beta1, 0.999),
             )
             self.optimizer_D = torch.optim.Adam(
                 itertools.chain(self.netD.parameters()),
-                lr=opt.dis.opt.lr,
-                betas=(opt.dis.opt.beta1, 0.999),
+                lr=opts.dis.opts.lr,
+                betas=(opts.dis.opts.beta1, 0.999),
             )
             self.optimizers = []
             self.optimizers.append(self.optimizer_G)
@@ -87,7 +87,7 @@ class SimMaskGenerator(BaseModel):
 
         if self.loss_name == "wgan":  # Get gradient penalty loss
             grad_penalty = networks.calc_gradient_penalty(
-                self.opt, self.netD, real_mask_d, fake_mask_d
+                self.opts, self.netD, real_mask_d, fake_mask_d
             )
             self.loss_D = (self.loss_D_real + self.loss_D_fake) * 0.5 + grad_penalty
         else:

--- a/models/sim_mask_generator.py
+++ b/models/sim_mask_generator.py
@@ -50,13 +50,13 @@ class SimMaskGenerator(BaseModel):
 
             self.optimizer_G = torch.optim.Adam(
                 itertools.chain(self.netG.parameters()),
-                lr=opts.gen.opts.lr,
-                betas=(opts.gen.opts.beta1, 0.999),
+                lr=opts.gen.optim.lr,
+                betas=(opts.gen.optim.beta1, 0.999),
             )
             self.optimizer_D = torch.optim.Adam(
                 itertools.chain(self.netD.parameters()),
-                lr=opts.dis.opts.lr,
-                betas=(opts.dis.opts.beta1, 0.999),
+                lr=opts.dis.optim.lr,
+                betas=(opts.dis.optim.beta1, 0.999),
             )
             self.optimizers = []
             self.optimizers.append(self.optimizer_G)

--- a/shared/defaults.yml
+++ b/shared/defaults.yml
@@ -32,7 +32,7 @@ data:
 # ----- Generator -----
 # ---------------------
 gen:
-  opt:
+  optim:
     optimizer: ExtraAdam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.9
     lr: 0.0005
@@ -70,7 +70,7 @@ gen:
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
-  opt:
+  optim:
     optimizer: Adam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.5
     lr: 0.0005

--- a/shared/defaults.yml
+++ b/shared/defaults.yml
@@ -66,7 +66,7 @@ gen:
 # ---------------------
 # ----- Generator -----
 # ---------------------
-  
+
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
@@ -95,7 +95,7 @@ dis:
 # ----- Model options -----
 # ------------------------
 
-model: 
+model:
   model_name: ""
   is_train: true
   use_gpu: true
@@ -107,8 +107,7 @@ model:
 # ----- Comet options ----
 # ------------------------
 
-
-comet: 
+comet:
   workspace: ""
   project_name: ""
   exp: None

--- a/shared/feature_pixelDA.yml
+++ b/shared/feature_pixelDA.yml
@@ -8,7 +8,7 @@ data:
     base: "/network/tmp1/ccai/data/mask_generation/11K" # ! Check output_dir
     train: train.json
     val: test.json
-  
+
   real_files:
     base: "/network/tmp1/ccai/data/mask_generation/real"
     train: train.json
@@ -26,14 +26,14 @@ data:
       p: 0.5
     - name: resize
       ignore: false
-      new_size: 256 #! Make sure this matches opt.data.img_size
+      new_size: 256 #! Make sure this matches opts.data.img_size
     - name: crop
       ignore: false
       height: 224
       width: 224
     - name: resize # ? this or change generator's output? Or resize larger then crop to 256?
       ignore: false
-      new_size: 256 #! Make sure this matches opt.data.img_size
+      new_size: 256 #! Make sure this matches opts.data.img_size
 
 # ---------------------
 # ----- Generator -----
@@ -73,7 +73,7 @@ gen:
 # ---------------------
 # ----- Discriminator -----
 # ---------------------
-  
+
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
@@ -105,7 +105,7 @@ dis:
 # ----- Model options -----
 # ------------------------
 
-model: 
+model:
   model_name: 'mask_generator'
   is_train: true
   use_gpu: true
@@ -118,7 +118,7 @@ model:
 # ------------------------
 
 
-comet: 
+comet:
   workspace: "sunandr"
   project_name: "mask-generator"
   exp: None #Will be defined in train.py

--- a/shared/feature_pixelDA.yml
+++ b/shared/feature_pixelDA.yml
@@ -39,7 +39,7 @@ data:
 # ----- Generator -----
 # ---------------------
 gen:
-  opt:
+  optim:
     optimizer: Adam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.9
     lr: 0.0005
@@ -77,7 +77,7 @@ gen:
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
-  opt:
+  optim:
     optimizer: Adam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.5
     lr: 0.0005

--- a/shared/feature_pixelDA.yml
+++ b/shared/feature_pixelDA.yml
@@ -17,7 +17,7 @@ data:
   img_size: 256
 
   loaders:
-    batch_size: 4
+    batch_size: 20
     shuffle: True
     num_workers: 4
   transforms:
@@ -134,10 +134,11 @@ train:
   log_level: 1 # 0: no log, 1: only aggregated losses, >1 detailed losses
   print_freq: 1
   output_dir: '/network/tmp1/ccai/data/mask_generation/output_files/11K_wgan_feature_pixelDA'
-  save_im_freq: 100
+  save_im_freq: 5000
   save_freq: 20000
   resume_checkpoint: false
   load_iter: 500000
+  tests_per_epoch: 4
 
 
 # -----------------------------

--- a/shared/sim.yml
+++ b/shared/sim.yml
@@ -19,14 +19,14 @@ data:
       p: 0.5
     - name: resize
       ignore: false
-      new_size: 256 #! Make sure this matches opt.data.img_size
+      new_size: 256 #! Make sure this matches opts.data.img_size
     - name: crop
       ignore: false
       height: 224
       width: 224
     - name: resize # ? this or change generator's output? Or resize larger then crop to 256?
       ignore: false
-      new_size: 256 #! Make sure this matches opt.data.img_size
+      new_size: 256 #! Make sure this matches opts.data.img_size
 
 # ---------------------
 # ----- Generator -----
@@ -66,7 +66,7 @@ gen:
 # ---------------------
 # ----- Generator -----
 # ---------------------
-  
+
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
@@ -95,7 +95,7 @@ dis:
 # ----- Model options -----
 # ------------------------
 
-model: 
+model:
   model_name: 'mask_generator'
   is_train: true
   use_gpu: true
@@ -108,7 +108,7 @@ model:
 # ------------------------
 
 
-comet: 
+comet:
   workspace: "sunandr"
   project_name: "mask-generator"
   exp: None #Will be defined in train.py

--- a/shared/sim.yml
+++ b/shared/sim.yml
@@ -1,7 +1,6 @@
-
+--- # ----------------
 # ----------------
 # ----- Data -----
-# ----------------
 data:
   files: # if one is not none it will override the dirs location
     base: "/network/tmp1/ccai/data/mask_generation/1000R"
@@ -32,7 +31,7 @@ data:
 # ----- Generator -----
 # ---------------------
 gen:
-  opt:
+  optim:
     optimizer: Adam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.9
     lr: 0.0005
@@ -70,7 +69,7 @@ gen:
 dis:
   soft_shift: 0.2 # label smoothing: real in U(1-soft_shift, 1), fake in U(0, soft_shift) # ! one-sided label smoothing
   flip_prob: 0.05 # label flipping
-  opt:
+  optim:
     optimizer: Adam # one in [Adam, ExtraAdam] default: Adam
     beta1: 0.5
     lr: 0.0005
@@ -96,24 +95,22 @@ dis:
 # ------------------------
 
 model:
-  model_name: 'mask_generator'
+  model_name: "mask_generator"
   is_train: true
   use_gpu: true
   lambdas: {}
-  loss_name: 'wgan'
+  loss_name: "wgan"
   verbose: False #print network at start
 
 # ------------------------
 # ----- Comet options ----
 # ------------------------
 
-
 comet:
   workspace: "sunandr"
   project_name: "mask-generator"
   exp: None #Will be defined in train.py
   display_size: 5 #Num images to display
-
 
 # ------------------------
 # ----- Train Params -----
@@ -123,12 +120,11 @@ train:
   lambdas: # scaling factors in the total loss
   log_level: 1 # 0: no log, 1: only aggregated losses, >1 detailed losses
   print_freq: 1
-  output_dir: './outputs'
+  output_dir: "./outputs"
   save_im_freq: 100
   save_freq: 20000
   resume_checkpoint: false
   load_iter: 500000
-
 
 # -----------------------------
 # ----- Validation Params -----

--- a/slurm_tmpdir.py
+++ b/slurm_tmpdir.py
@@ -1,0 +1,78 @@
+"""This file creates a new data file like train.json in slurm_tmpdir
+and zips the data there:
+1. read data file list from file
+2. create zip file of the data
+3. copy it to slurm_tmpdir
+4. create new data file list updated to use data on slurm_tmpdir
+"""
+import shutil
+import zipfile
+import argparse
+import json
+from pathlib import Path
+import os
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--file", help="Path to file containing the data list")
+    parser.add_argument("-l", "--limit", help="Limit number of samples", default=-1)
+    args = parser.parse_args()
+
+    dir = Path(args.file).resolve().parent
+
+    # load data list [{"x": p1, "m": p2}, ...]
+    with open(args.file, "r") as f:
+        data = json.load(f)
+
+    if args.limit > 0:
+        data = data[: args.limit]
+
+    # create a list of files to zip, per domain ("x" and "m" for instance)
+    zips = {}
+    for d in data:
+        for k, v in d.items():
+            if k not in zips:
+                zips[k] = []
+            zips[k].append(v)
+
+    print("Files listed")
+
+    # create the actual zip file from the lists of paths
+    for k, v in zips.items():
+        zip_path = dir / f"{Path(args.file).stem}_{k}.zip"
+        print("Creating", zip_path)
+        if not zip_path.exists():
+            with zipfile.ZipFile(zip_path, "w") as zipMe:
+                for i, path in enumerate(v):
+                    if i % 25 == 0:
+                        print(i, end="\r", flush=True)
+                    zipMe.write(
+                        path,
+                        Path(zip_path.stem) / Path(path).name,
+                        compress_type=zipfile.ZIP_DEFLATED,
+                    )
+            print("Ok. Copying...", end="", flush=True)
+        else:
+            print("Using already existing zip. Copying...", end="", flush=True)
+        # copy zip file to slurm_tmpdir
+        shutil.copyfile(zip_path, Path(os.environ["SLURM_TMPDIR"]) / zip_path.name)
+        # write new data list file to slurm_tmpdir
+        with open(Path(os.environ["SLURM_TMPDIR"]) / Path(args.file).name, "w") as f:
+            json.dump(
+                [
+                    {
+                        k: str(
+                            Path(os.environ["SLURM_TMPDIR"])
+                            / Path(zip_path.stem)
+                            / Path(v).name
+                        )
+                        for k, v in d.items()
+                    }
+                    for d in data
+                ],
+                f,
+            )
+        print("ok. Unzipping...", end="", flush=True)
+        # unzip file
+        with zipfile.ZipFile(zip_path, "r") as zip_ref:
+            zip_ref.extractall(Path(os.environ["SLURM_TMPDIR"]))

--- a/test.py
+++ b/test.py
@@ -14,33 +14,33 @@ if __name__ == "__main__":
     root = Path(__file__).parent.resolve()
     opt_file = "prev_experiments/11k_wgan_feature_pixelDA.yml"
 
-    opt = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
+    opts = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
 
-    opt = set_mode("test", opt)
-    opt.data.loaders.batch_size = 1
-    val_loader = get_loader(opt)
+    opts = set_mode("test", opts)
+    opts.data.loaders.batch_size = 1
+    val_loader = get_loader(opts)
     dataset_size = len(val_loader)
 
     print("#testing images = %d" % dataset_size)
 
     comet_exp = Experiment(
-        workspace=opt.comet.workspace, project_name=opt.comet.project_name
+        workspace=opts.comet.workspace, project_name=opts.comet.project_name
     )
     if comet_exp is not None:
         comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
-        comet_exp.log_parameters(opt)
+        comet_exp.log_parameters(opts)
 
-    checkpoint_directory, image_directory = prepare_sub_folder(opt.train.output_dir)
+    checkpoint_directory, image_directory = prepare_sub_folder(opts.train.output_dir)
 
-    opt.comet.exp = comet_exp
+    opts.comet.exp = comet_exp
 
-    model = create_model(opt)
+    model = create_model(opts)
     model.setup()
 
     total_steps = 0
 
     for i, data in enumerate(val_loader):
         with Timer("Elapsed time in update " + str(i) + ": %f"):
-            total_steps += opt.data.loaders.batch_size
+            total_steps += opts.data.loaders.batch_size
             model.set_input(Dict(data))
             model.save_test_images([Dict(data)], total_steps)

--- a/train.py
+++ b/train.py
@@ -60,7 +60,9 @@ if __name__ == "__main__":
             model.optimize_parameters()
 
             if total_steps // batch_size % 25 == 0:
-                print(time_str.format(total_steps, avg_duration(times)))
+                avg = avg_duration(times)
+                print(time_str.format(total_steps, avg))
+                model.comet_exp.log_metric("sample_time", avg, step=total_steps)
 
             if total_steps % opts.val.save_im_freq == 0:
                 model.save_test_images(test_display_images, total_steps)

--- a/train.py
+++ b/train.py
@@ -53,13 +53,15 @@ if __name__ == "__main__":
     # ! important to do test first
     val_opt = set_mode("test", opts)
     val_loader = get_loader(val_opt, real=True, no_check=args.no_check)
+    val_iter = iter(val_loader)
     test_display_images = [
-        Dict(iter(val_loader).next()) for i in range(opts.comet.display_size)
+        Dict(val_iter.next()) for i in range(opts.comet.display_size)
     ]
 
     train_loader = get_loader(opts, real=True, no_check=args.no_check)
+    train_iter = iter(train_loader)
     train_display_images = [
-        Dict(iter(train_loader).next()) for i in range(opts.comet.display_size)
+        Dict(train_iter.next()) for i in range(opts.comet.display_size)
     ]
 
     print("Loaders created. Creating network:")

--- a/train.py
+++ b/train.py
@@ -2,6 +2,7 @@ from comet_ml import Experiment
 from time import time
 from pathlib import Path
 from addict import Dict
+import numpy as np
 from utils import (
     load_opts,
     set_mode,
@@ -9,6 +10,7 @@ from utils import (
     create_model,
     avg_duration,
     flatten_opts,
+    print_opts,
 )
 from data.datasets import get_loader
 from collections import deque
@@ -20,6 +22,8 @@ if __name__ == "__main__":
     opt_file = "shared/feature_pixelDA.yml"
     opts = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
     opts = set_mode("train", opts)
+    flats = flatten_opts(opts)
+    print_opts(flats)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -31,23 +35,33 @@ if __name__ == "__main__":
         default=opts.comet.project_name,
         help="Comet project_name",
     )
+    parser.add_argument(
+        "-n",
+        "--no_check",
+        action="store_true",
+        default=False,
+        help="Prevent sample existence checking for faster dev",
+    )
     args = parser.parse_args()
 
     comet_exp = Experiment(workspace=args.workspace, project_name=args.project_name)
     comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
-    comet_exp.log_parameters(flatten_opts(opts))
+    comet_exp.log_parameters(flats)
 
+    print("Creating loaders:")
     # ! important to do test first
     val_opt = set_mode("test", opts)
-    val_loader = get_loader(val_opt, real=True)
+    val_loader = get_loader(val_opt, real=True, no_check=args.no_check)
     test_display_images = [
         Dict(iter(val_loader).next()) for i in range(opts.comet.display_size)
     ]
 
-    train_loader = get_loader(opts, real=True)
+    train_loader = get_loader(opts, real=True, no_check=args.no_check)
     train_display_images = [
         Dict(iter(train_loader).next()) for i in range(opts.comet.display_size)
     ]
+
+    print("Loaders created. Creating network:")
 
     opts.comet.exp = comet_exp
     model = create_model(opts)
@@ -55,9 +69,12 @@ if __name__ == "__main__":
 
     total_steps = 0
     times = deque([0], maxlen=100)
+    model_times = deque([0], maxlen=100)
     batch_size = opts.data.loaders.batch_size
-    time_str = "Average time per sample at step {}: {:.3f}"
+    time_str = "Average time per sample at step {} ({}): {:.3f} (model only: {:.3f})"
     checkpoint_directory, image_directory = prepare_sub_folder(opts.train.output_dir)
+
+    print(">>> Starting training <<<")
 
     for epoch in range(opts.train.epochs):
         for i, data in enumerate(train_loader):
@@ -67,9 +84,15 @@ if __name__ == "__main__":
             model.set_input(Dict(data))
             model.optimize_parameters()
 
-            if total_steps // batch_size % 25 == 0:
+            model_times.append(time() - times[-1])
+
+            if total_steps // batch_size % 100 == 0:
                 avg = avg_duration(times, batch_size)
-                print(time_str.format(total_steps, avg))
+                print(
+                    time_str.format(
+                        total_steps, epoch, avg, np.mean(model_times) / batch_size
+                    )
+                )
                 model.comet_exp.log_metric("sample_time", avg, step=total_steps)
 
             if total_steps % opts.val.save_im_freq == 0:

--- a/train.py
+++ b/train.py
@@ -15,6 +15,7 @@ from utils import (
 from data.datasets import get_loader
 from collections import deque
 import argparse
+from models.mask_generator import MaskGenerator
 
 if __name__ == "__main__":
 
@@ -64,7 +65,7 @@ if __name__ == "__main__":
     print("Loaders created. Creating network:")
 
     opts.comet.exp = comet_exp
-    model = create_model(opts)
+    model: MaskGenerator = create_model(opts)
     model.setup()
 
     total_steps = 0

--- a/train.py
+++ b/train.py
@@ -119,7 +119,9 @@ if __name__ == "__main__":
                 comet_exp.log_metric("sample_time", avg, step=total_steps)
                 comet_exp.log_metric("model_time", mod_times, step=total_steps)
             if i in test_idx or total_steps == batch_size:
-                model.save_test_images(test_display_images, total_steps)
+                print("Inferring test display images...", end="", flush=True)
+                t = model.save_test_images(test_display_images, total_steps)
+                print("ok in {:.2f}s.".format(t))
 
         print("saving (epoch %d, total_steps %d)" % (epoch, total_steps))
         save_suffix = "iter_%d" % total_steps

--- a/train.py
+++ b/train.py
@@ -6,18 +6,17 @@ from utils import load_opts, set_mode, prepare_sub_folder, create_model, avg_dur
 from data.datasets import get_loader
 from collections import deque
 
-# from data import CreateDataLoader
-# from models import create_model
-# from util.visualizer import Visualizer
-
 if __name__ == "__main__":
     root = Path(__file__).parent.resolve()
     opt_file = "shared/feature_pixelDA.yml"
-
     opts = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
+    opts = set_mode("train", opts)
+
     comet_exp = Experiment(
         workspace=opts.comet.workspace, project_name=opts.comet.project_name
     )
+    comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
+    comet_exp.log_parameters(opts)
 
     # ! important to do test first
     val_opt = set_mode("test", opts)
@@ -26,23 +25,12 @@ if __name__ == "__main__":
         Dict(iter(val_loader).next()) for i in range(opts.comet.display_size)
     ]
 
-    opts = set_mode("train", opts)
-    loader = get_loader(opts, real=True)
+    train_loader = get_loader(opts, real=True)
     train_display_images = [
-        Dict(iter(loader).next()) for i in range(opts.comet.display_size)
+        Dict(iter(train_loader).next()) for i in range(opts.comet.display_size)
     ]
 
-    dataset_size = len(loader)
-    print("#training images = %d" % dataset_size)
-
-    if comet_exp is not None:
-        comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
-        comet_exp.log_parameters(opts)
-
-    checkpoint_directory, image_directory = prepare_sub_folder(opts.train.output_dir)
-
     opts.comet.exp = comet_exp
-
     model = create_model(opts)
     model.setup()
 
@@ -50,9 +38,10 @@ if __name__ == "__main__":
     times = deque([0], maxlen=100)
     batch_size = opts.data.loaders.batch_size
     time_str = "Average time per sample at step {}: {:.3f}"
+    checkpoint_directory, image_directory = prepare_sub_folder(opts.train.output_dir)
 
     for epoch in range(opts.train.epochs):
-        for i, data in enumerate(loader):
+        for i, data in enumerate(train_loader):
             times.append(time())
             total_steps += batch_size
 

--- a/train.py
+++ b/train.py
@@ -110,7 +110,7 @@ if __name__ == "__main__":
             total_steps += batch_size
 
             model.set_input(Dict(data))
-            model.optimize_parameters()
+            model.optimize_parameters(total_steps)
 
             model_times.append(time() - times[-1])
             if total_steps // batch_size % 100 == 0:

--- a/train.py
+++ b/train.py
@@ -14,22 +14,22 @@ if __name__ == "__main__":
     root = Path(__file__).parent.resolve()
     opt_file = "shared/feature_pixelDA.yml"
 
-    opt = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
+    opts = load_opts(path=root / opt_file, default=root / "shared/defaults.yml")
     comet_exp = Experiment(
-        workspace=opt.comet.workspace, project_name=opt.comet.project_name
+        workspace=opts.comet.workspace, project_name=opts.comet.project_name
     )
 
     # ! important to do test first
-    val_opt = set_mode("test", opt)
+    val_opt = set_mode("test", opts)
     val_loader = get_loader(val_opt, real=True)
     test_display_images = [
-        Dict(iter(val_loader).next()) for i in range(opt.comet.display_size)
+        Dict(iter(val_loader).next()) for i in range(opts.comet.display_size)
     ]
 
-    opt = set_mode("train", opt)
-    loader = get_loader(opt, real=True)
+    opts = set_mode("train", opts)
+    loader = get_loader(opts, real=True)
     train_display_images = [
-        Dict(iter(loader).next()) for i in range(opt.comet.display_size)
+        Dict(iter(loader).next()) for i in range(opts.comet.display_size)
     ]
 
     dataset_size = len(loader)
@@ -37,21 +37,21 @@ if __name__ == "__main__":
 
     if comet_exp is not None:
         comet_exp.log_asset(file_data=str(root / opt_file), file_name=root / opt_file)
-        comet_exp.log_parameters(opt)
+        comet_exp.log_parameters(opts)
 
-    checkpoint_directory, image_directory = prepare_sub_folder(opt.train.output_dir)
+    checkpoint_directory, image_directory = prepare_sub_folder(opts.train.output_dir)
 
-    opt.comet.exp = comet_exp
+    opts.comet.exp = comet_exp
 
-    model = create_model(opt)
+    model = create_model(opts)
     model.setup()
 
     total_steps = 0
     times = deque([0], maxlen=100)
-    batch_size = opt.data.loaders.batch_size
+    batch_size = opts.data.loaders.batch_size
     time_str = "Average time per sample at step {}: {:.3f}"
 
-    for epoch in range(opt.train.epochs):
+    for epoch in range(opts.train.epochs):
         for i, data in enumerate(loader):
             times.append(time())
             total_steps += batch_size
@@ -62,10 +62,10 @@ if __name__ == "__main__":
             if total_steps // batch_size % 25 == 0:
                 print(time_str.format(total_steps, avg_duration(times)))
 
-            if total_steps % opt.val.save_im_freq == 0:
+            if total_steps % opts.val.save_im_freq == 0:
                 model.save_test_images(test_display_images, total_steps)
 
-            if total_steps % opt.train.save_freq == 0:
+            if total_steps % opts.train.save_freq == 0:
                 print(
                     "saving the latest model (epoch %d, total_steps %d)"
                     % (epoch, total_steps)

--- a/train.py
+++ b/train.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
                 comet_exp.log_metric("sample_time", avg, step=total_steps)
                 comet_exp.log_metric("model_time", mod_times, step=total_steps)
             if i in test_idx or total_steps == batch_size:
-                print("Inferring test display images...", end="", flush=True)
+                print(f"({total_steps}) Inferring test images...", end="", flush=True)
                 t = model.save_test_images(test_display_images, total_steps)
                 print("ok in {:.2f}s.".format(t))
 

--- a/utils.py
+++ b/utils.py
@@ -57,7 +57,7 @@ def set_data_paths(opts):
 
 
 def set_mode(mode, opts):
-
+    opts = opts.copy()
     if mode == "train":
         opts.model.is_train = True
     elif mode == "test":

--- a/utils.py
+++ b/utils.py
@@ -47,14 +47,13 @@ def set_data_paths(opts):
     """
 
     for mode in ["train", "val"]:
-        for domain in opts.data.files[mode]:
-            opts.data.files[mode] = str(
-                Path(opts.data.files.base) / opts.data.files[mode]
+        opts.data.files[mode] = str(
+            Path(opts.data.files.base) / opts.data.files[mode]
+        )
+        if opts.data.use_real:
+            opts.data.real_files[mode] = str(
+                Path(opts.data.real_files.base) / opts.data.real_files[mode]
             )
-            if opts.data.use_real:
-                opts.data.real_files[mode] = str(
-                    Path(opts.data.real_files.base) / opts.data.real_files[mode]
-                )
     return opts
 
 

--- a/utils.py
+++ b/utils.py
@@ -66,45 +66,45 @@ def set_mode(mode, opts):
     return opts
 
 
-def create_model(opt):
+def create_model(opts):
     # Find model in "models" folder
-    model_name = str(opt.model.model_name)
+    model_name = str(opts.model.model_name)
     modellib = importlib.import_module("models." + model_name)
     target_model_name = model_name.replace("_", "")
     for name, cls in modellib.__dict__.items():
         if name.lower() == target_model_name.lower() and issubclass(cls, BaseModel):
             model = cls
     instance = model()
-    instance.initialize(opt)
+    instance.initialize(opts)
     # print("model [%s] was created" % (instance.name()))
     return instance
 
 
-def get_scheduler(optimizer, opt):
-    if opt.lr_policy == "lambda":
+def get_scheduler(optimizer, opts):
+    if opts.lr_policy == "lambda":
 
         def lambda_rule(epoch):
-            lr_l = 1.0 - max(0, epoch + opt.epoch_count - opt.niter) / float(
-                opt.niter_decay + 1
+            lr_l = 1.0 - max(0, epoch + opts.epoch_count - opts.niter) / float(
+                opts.niter_decay + 1
             )
             return lr_l
 
         scheduler = lr_scheduler.LambdaLR(optimizer, lr_lambda=lambda_rule)
-    elif opt.lr_policy == "step":
+    elif opts.lr_policy == "step":
         scheduler = lr_scheduler.StepLR(
-            optimizer, step_size=opt.lr_decay_iters, gamma=0.1
+            optimizer, step_size=opts.lr_decay_iters, gamma=0.1
         )
-    elif opt.lr_policy == "plateau":
+    elif opts.lr_policy == "plateau":
         scheduler = lr_scheduler.ReduceLROnPlateau(
             optimizer, mode="min", factor=0.2, threshold=0.01, patience=5
         )
-    elif opt.lr_policy == "cosine":
+    elif opts.lr_policy == "cosine":
         scheduler = lr_scheduler.CosineAnnealingLR(
-            optimizer, T_max=opt.niter, eta_min=0
+            optimizer, T_max=opts.niter, eta_min=0
         )
     else:
         return NotImplementedError(
-            "learning rate policy [%s] is not implemented", opt.lr_policy
+            "learning rate policy [%s] is not implemented", opts.lr_policy
         )
     return scheduler
 

--- a/utils.py
+++ b/utils.py
@@ -8,6 +8,7 @@ from models.base_model import BaseModel
 import time
 import torchvision.utils as vutils
 from torch.optim import lr_scheduler
+import numpy as np
 
 
 def load_opts(path=None, default=None):
@@ -47,9 +48,7 @@ def set_data_paths(opts):
     """
 
     for mode in ["train", "val"]:
-        opts.data.files[mode] = str(
-            Path(opts.data.files.base) / opts.data.files[mode]
-        )
+        opts.data.files[mode] = str(Path(opts.data.files.base) / opts.data.files[mode])
         if opts.data.use_real:
             opts.data.real_files[mode] = str(
                 Path(opts.data.real_files.base) / opts.data.real_files[mode]
@@ -158,3 +157,16 @@ def write_images(
 
     if comet_exp is not None:
         comet_exp.log_image(image_grid, name="test_iter_" + str(curr_iter))
+
+
+def avg_duration(times):
+    """Given a list of times, return the average duration (i.e. difference of times)
+
+    Args:
+        times ([type]): [description]
+
+    Returns:
+        [type]: [description]
+    """
+    t = list(times)
+    return (np.array(t + [0]) - np.array([0] + t))[1:-1].mean()

--- a/utils.py
+++ b/utils.py
@@ -73,7 +73,8 @@ def set_data_paths(opts):
         )
         if opts.data.use_real:
             opts.data.real_files[mode] = str(
-                Path(env_to_path(opts.data.files.base)) / opts.data.real_files[mode]
+                Path(env_to_path(opts.data.real_files.base))
+                / opts.data.real_files[mode]
             )
     return opts
 


### PR DESCRIPTION
No breaking changes, just a few print improvements and the test set is now deterministic

Main change for you (regardless of code formatting and imports etc.):

1. All the `opt` variables were changed to `opts`, because you had them interchangeably all over the code and that's very error-prone. So I made a choice for you to `opts`
2. The `opt` section in `gen` and `dis` which refer to the optimization parameters were confusingly close to `opts` (options) so I renamed them to `optim` for clarity
3. `comet` workspace and project can be specified in the config file but overridden by command-line args. For instance I use: `python train.py -w vict0rsch -p maskgen`